### PR TITLE
Align link text and icon vertically

### DIFF
--- a/components/EventCard/EventCard.css
+++ b/components/EventCard/EventCard.css
@@ -51,9 +51,11 @@
 }
 
 .event-card__link {
+    display: inline-flex;
+    align-items: center;
+
     font-size: 12px;
     line-height: 16px;
-    padding: 4px 0;
 
     color: #0000cc;
     text-decoration: none;


### PR DESCRIPTION
Подвинул вертикально иконки и текста «Подробнее».

**Было:** 
![Мероприятия](https://user-images.githubusercontent.com/3251438/61168835-ac6e6100-a55c-11e9-8616-1d858bd8cae0.png)


**Стало:**
![Мероприятия](https://user-images.githubusercontent.com/3251438/61168824-82b53a00-a55c-11e9-8c85-2867428f4b48.png)
